### PR TITLE
fix: resolve 422 error for LibreChat requests (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 .pytest_cache/
 dist/
 build/
+docker-compose.override.yml

--- a/models.py
+++ b/models.py
@@ -14,4 +14,5 @@ class JinaRerankerResponse(BaseModel):
 class JinaRerankerRequest(BaseModel):
     query: str
     documents: List[str]
-    batch_size: int
+    batch_size: int = 256
+    return_documents: bool = True


### PR DESCRIPTION
## Summary
This PR fixes the issue where the API returns an HTTP 422 error when receiving requests from LibreChat.

## Bug Description
As reported in #1, requests sent from LibreChat trigger a `422 Unprocessable Entity` error. This happens because the request payload sent by LibreChat does not match the current Pydantic schema in the API.

## Steps to Reproduce
1. Send a valid POST request to `/librechat/v1/rerank` from LibreChat.
2. Observe the response: `HTTP 422 Unprocessable Entity`.

## The Fix
- Set a default value for `batch_size`
- Add the `return_documents` variable

## Verification
- [x] Verified that valid requests now return `200 OK`.

Closes #1